### PR TITLE
move isByPassInvul check

### DIFF
--- a/common/src/main/java/com/illusivesoulworks/charmofundying/mixin/MixinLivingEntity.java
+++ b/common/src/main/java/com/illusivesoulworks/charmofundying/mixin/MixinLivingEntity.java
@@ -34,10 +34,12 @@ public class MixinLivingEntity {
   @Inject(at = @At("HEAD"), method = "checkTotemDeathProtection", cancellable = true)
   private void charmofundying$checkTotemDeathProtection(DamageSource src,
                                                         CallbackInfoReturnable<Boolean> cir) {
-    if (src.isBypassInvul()) {
-      cir.setReturnValue(false);
-    } else if (CharmOfUndyingCommonMod.hasTotem((LivingEntity) (Object) this)) {
-      cir.setReturnValue(true);
+    if (CharmOfUndyingCommonMod.hasTotem((LivingEntity) (Object) this)) {
+      if (src.isBypassInvul()) {
+        cir.setReturnValue(false);
+      } else {
+        cir.setReturnValue(true);
+      }
     }
   }
 }


### PR DESCRIPTION
This PR moves the `isByPassInvul` check inside the hasTotem check to fix a mod conflict with the [void totem](https://www.curseforge.com/minecraft/mc-mods/voidtotem) mod, which only fires if the player is in the void (using `checkTotemDeathProtection`). Previous to this PR the void totem didn't work when the charm of undying mod is installed as it always canceled the `checkTotemDeathProtection` if the player suffers from damage in the void (isBypassInvul also means void damage). 
This PR now fixes this issue. 

Issue reference: Affehund/VoidTotem#17